### PR TITLE
fix 'Error: Unsupported framework' on some platforms when deployed

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,3 +70,5 @@ app.post('/webhook', (req, res) => {
 })
 
 app.listen(port, () => console.log(`Webhook Sample Node.js listening on port ${port}!`))
+
+module.exports = app


### PR DESCRIPTION
Deploying on cloud providers like deta.sh raises an `Error: Unsupported framework` when the app is deployed. This is fixed by adding a `module.exports = app` at the end of index.js.